### PR TITLE
Add Rule34 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Currently supported URLs:
 - gelbooru.com
 - danbooru.donmai.us
 - aibooru.online
+- rule34.xxx
 
 ## Future Plans
-- Add support for other boorus. Currently planned supported URLs are: ~~danbooru.donmai.us~~, chan.sankakucomplex.com, idol.sankakucomplex.com, ~~aibooru.online~~, and rule34.xxx.
+- Add support for other boorus. Currently planned supported URLs are: ~~danbooru.donmai.us~~, chan.sankakucomplex.com, idol.sankakucomplex.com, ~~aibooru.online~~, and ~~rule34.xxx~~.
 
 ## Version History
 - 1.0.0
@@ -21,3 +22,5 @@ Currently supported URLs:
     - AIbooru links are now supported.
 - 1.3.1
     - Fixed typo causing Danbooru and AIbooru links containing URL query parameters (usually from site searches) causing errors when trying to fetch.
+- 1.4.0
+    - Added support for rule34.xxx links.

--- a/scripts/sd-webui-booru-tags-to-prompt.py
+++ b/scripts/sd-webui-booru-tags-to-prompt.py
@@ -1,7 +1,7 @@
 # Booru Tags to Prompt for Stable Diffusion WebUI Forge
 # Script by David R. Collins
 #
-# Version 1.3.1
+# Version 1.4.0
 # Released under the GNU General Public License Version 3, 29 June 2007
 #
 # Project based on ideas from danbooru-prompt by EnsignMK (https://github.com/EnsignMK/danbooru-prompt)
@@ -156,13 +156,28 @@ def fetchGelbooruTags(url):
         parsed = (", ").join(parsed)
         return (parsed)
 
-def fetchRuleThirtyFourTags(url)
-    return "Rule34 Url Entered; Not Yet Implemented"
+def fetchRuleThirtyFourTags(url):
+    
+    # Read the HTML content and parse it via BeautifulSoup.
+    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.1.0'}).text
+    parsedHtml = BeautifulSoup(rawHtml, 'html.parser')
 
-def fetchSankakuComplexChanTags(url)
+    imageElement = parsedHtml.find(attrs={"id" : "image"})
+
+    # imageElement now has the entire <img ... element in it. Get the tags from the "alt" attribute
+    # and properly format them.
+    parsedTags = []
+    for tag in imageElement["alt"].split():
+        tag = tag.replace("_", " ")
+        parsedTags.append(tag)
+    parsedTags = (", ").join(parsedTags)
+
+    return parsedTags
+
+def fetchSankakuComplexChanTags(url):
     return "sankakuComplex Chan Url Entered; Not Yet Implemented"
 
-def fetchSankakuComplexIdolTags(url)
+def fetchSankakuComplexIdolTags(url):
     return "sankakuComplex Idol Url Entered; Not Yet Implemented"
 
 class BooruPromptsScript(scripts.Script):


### PR DESCRIPTION
Added support for the Rule34.xxx domain.
Fixed issue with the stubs from the previous version. (Missed colons.)
Bumped version to 1.4.0.

Addresses #10.