### PR TITLE
Added Preliminary Sankaku Complex Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,15 @@ Currently supported URLs:
 - danbooru.donmai.us
 - aibooru.online
 - rule34.xxx
+- chan.sankakucomplex.com[1]
+- idol.sankakucomplex.com[1]
+
+[1]: Sankaku Complex requires the user log in to see the entire list of tags. This script currently does not support this functionality. I'd like to add it at a later point, but I don't feel that my Python skills are currently up to the task. I'm going to leave it as a todo item for later at this time. ~TrueKam
 
 ## Future Plans
-- Add support for other boorus. Currently planned supported URLs are: ~~danbooru.donmai.us~~, chan.sankakucomplex.com, idol.sankakucomplex.com, ~~aibooru.online~~, and ~~rule34.xxx~~.
+- All planned boorus are currently supported.
+- Allow name and password for sites that don't show all the tags for anonymous users. (Looking at you, Sankaku Complex.)
+    - To do this, I'll have to figure out how SD-WebUI handles creating settings pages so I don't have to force end users to manually edit this script since some might not have the level of comfort required to do so. It'll take some work, so it's currently back-burnered.
 
 ## Version History
 - 1.0.0
@@ -24,3 +30,5 @@ Currently supported URLs:
     - Fixed typo causing Danbooru and AIbooru links containing URL query parameters (usually from site searches) causing errors when trying to fetch.
 - 1.4.0
     - Added support for rule34.xxx links.
+- 1.5.0
+    - Added support for chan.sankakucomplex.com and idol.sankakucomplex.com.

--- a/scripts/sd-webui-booru-tags-to-prompt.py
+++ b/scripts/sd-webui-booru-tags-to-prompt.py
@@ -1,7 +1,7 @@
 # Booru Tags to Prompt for Stable Diffusion WebUI Forge
 # Script by David R. Collins
 #
-# Version 1.4.0
+# Version 1.5.0
 # Released under the GNU General Public License Version 3, 29 June 2007
 #
 # Project based on ideas from danbooru-prompt by EnsignMK (https://github.com/EnsignMK/danbooru-prompt)
@@ -59,7 +59,7 @@ def fetchAibooruTags(url):
         url = url[:pos]
     url = url + ".json"
     # Read the HTML content and parse it via BeautifulSoup.
-    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.1.0'})
+    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.5.0'})
     parsedHtml = rawHtml.json()
 
     artistTag = parsedHtml["tag_string_artist"]
@@ -96,7 +96,7 @@ def fetchDanbooruTags(url):
         url = url[:pos]
     url = url + ".json"
     # Read the HTML content and parse it via BeautifulSoup.
-    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.1.0'})
+    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.5.0'})
     parsedHtml = rawHtml.json()
 
     artistTag = parsedHtml["tag_string_artist"]
@@ -128,7 +128,7 @@ def fetchDanbooruTags(url):
 def fetchGelbooruTags(url):
 
     # Read the HTML content and parse it via BeautifulSoup.
-    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.1.0'}).text
+    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.5.0'}).text
     parsedHtml = BeautifulSoup(rawHtml, 'html.parser')
 
     # Parse the HTML to find the 'section' element that includes the 'data-md5' attribute, then extract that attribute
@@ -159,7 +159,7 @@ def fetchGelbooruTags(url):
 def fetchRuleThirtyFourTags(url):
     
     # Read the HTML content and parse it via BeautifulSoup.
-    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.1.0'}).text
+    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.5.0'}).text
     parsedHtml = BeautifulSoup(rawHtml, 'html.parser')
 
     imageElement = parsedHtml.find(attrs={"id" : "image"})
@@ -175,10 +175,30 @@ def fetchRuleThirtyFourTags(url):
     return parsedTags
 
 def fetchSankakuComplexChanTags(url):
-    return "sankakuComplex Chan Url Entered; Not Yet Implemented"
+    # Read the HTML content and parse it via BeautifulSoup.
+    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.5.0'}).text
+    parsedHtml = BeautifulSoup(rawHtml, 'html.parser')
+
+    parsedTags = []
+    tagElements = parsedHtml.find_all(attrs={"class" : "tag-link"})
+    for tag in tagElements:
+        parsedTags.extend(tag.contents)
+    tagString = (", ").join(parsedTags).lower()
+    
+    return tagString
 
 def fetchSankakuComplexIdolTags(url):
-    return "sankakuComplex Idol Url Entered; Not Yet Implemented"
+    # Read the HTML content and parse it via BeautifulSoup.
+    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.5.0'}).text
+    parsedHtml = BeautifulSoup(rawHtml, 'html.parser')
+
+    parsedTags = []
+    tagElements = parsedHtml.find_all(attrs={"class" : "tag-link"})
+    for tag in tagElements:
+        parsedTags.extend(tag.contents)
+    tagString = (", ").join(parsedTags).lower()
+    
+    return tagString
 
 class BooruPromptsScript(scripts.Script):
     def __init__(self) -> None:


### PR DESCRIPTION
Added support for Sankaku Complex Idol and Channel boorus. These function as expected, but cannot grab the entire list of tags if the user isn't logged in. Support for providing a user name and password is being investigated.
Updated documentation.
Bumped version to 1.5.0 and updated user-agent string used for web requests.

Addresses #5 and #6.