### PR TITLE
Update URL Detection to Fix Detection Failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BooruLinkPrompt
 A StableDiffusion-WebUI Forge script to get a list of tags from supported image boards and add to a prompt.
 Currently supported URLs:
-- aibooru.onling
+- aibooru.online
 - chan.sankakucomplex.com [1]
 - danbooru.donmai.us
 - e621.net

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Version History
+- 1.7.2
+  - Fixed calls for sites using index.php to not require the URL to explicitly include "index.php" in them so the web server can automatically resolve this and links copied/shared from apps like Boorusama will function properly.
 - 1.7.1
-    - Gelbooru removed (or changed the URL for, or simply changed permissions for) their API, so the method I was using to get the tags no longer works. Reworked the algorithm to get the tags so it just uses the originally downloaded HTML instead of parsing that for the image's hash then contacting the API. The API was more elegant, but technically caused a second web call so this is a faster solution.
+  - Gelbooru removed (or changed the URL for, or simply changed permissions for) their API, so the method I was using to get the tags no longer works. Reworked the algorithm to get the tags so it just uses the originally downloaded HTML instead of parsing that for the image's hash then contacting the API. The API was more elegant, but technically caused a second web call so this is a faster solution.
 - 1.7.0
   - Added support for tbib.org (The Big Image Board) and e621.net.
 - 1.6.0

--- a/scripts/sd-webui-booru-tags-to-prompt.py
+++ b/scripts/sd-webui-booru-tags-to-prompt.py
@@ -1,7 +1,7 @@
 # Booru Tags to Prompt for Stable Diffusion WebUI Forge
 # Script by David R. Collins
 #
-# Version 1.7.1
+# Version 1.7.2
 # Released under the GNU General Public License Version 3, 29 June 2007
 #
 # Project based on ideas from danbooru-prompt by EnsignMK (https://github.com/EnsignMK/danbooru-prompt)
@@ -36,13 +36,13 @@ def fetchTags(url):
     elif "e621.net/posts" in url:
         return fetchESixTwoOneTags(url)
     
-    elif "gelbooru.com/index.php" in url:
+    elif "gelbooru.com" in url:
         return fetchGelbooruTags(url)
     
-    elif "rule34.xxx/index.php" in url:
+    elif "rule34.xxx" in url:
         return fetchRuleThirtyFourTags(url)
     
-    elif "safebooru.org/index.php" in url:
+    elif "safebooru.org" in url:
         return fetchSafebooruTags(url)
     
     elif ("chan.sankakucomplex.com" in url) and ("posts" in url):
@@ -55,7 +55,7 @@ def fetchTags(url):
         # This way /should/ allow any language that they add into the function.
         return fetchSankakuComplexIdolTags(url)
 
-    elif "tbib.org/index.php" in url:
+    elif "tbib.org" in url:
         return fetchTheBigImageBoardTags(url)
     
     else:
@@ -69,7 +69,7 @@ def fetchAibooruTags(url):
         url = url[:pos]
     url = url + ".json"
     # Read the HTML content and parse it via BeautifulSoup.
-    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.7.1'})
+    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.7.2'})
     parsedHtml = rawHtml.json()
 
     artistTag = parsedHtml["tag_string_artist"]
@@ -106,7 +106,7 @@ def fetchDanbooruTags(url):
         url = url[:pos]
     url = url + ".json"
     # Read the HTML content and parse it via BeautifulSoup.
-    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.7.1'})
+    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.7.2'})
     parsedHtml = rawHtml.json()
 
     artistTag = parsedHtml["tag_string_artist"]
@@ -156,7 +156,7 @@ def fetchESixTwoOneTags(url):
 def fetchGelbooruTags(url):
 
     # Read the HTML content and parse it via BeautifulSoup.
-    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.7.1'}).text
+    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.7.2'}).text
     parsedHtml = BeautifulSoup(rawHtml, 'html.parser')
 
     # Parse the HTML to find the 'section' element that includes the 'data-md5' attribute, then extract that attribute
@@ -179,7 +179,7 @@ def fetchGelbooruTags(url):
 
 def fetchRuleThirtyFourTags(url):
     # Read the HTML content and parse it via BeautifulSoup.
-    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.7.1'}).text
+    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.7.2'}).text
     parsedHtml = BeautifulSoup(rawHtml, 'html.parser')
 
     imageElement = parsedHtml.find(attrs={"id" : "image"})
@@ -196,7 +196,7 @@ def fetchRuleThirtyFourTags(url):
 
 def fetchSafebooruTags(url):
     # Read the HTML content and parse it via BeautifulSoup.
-    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.7.1'}).text
+    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.7.2'}).text
     parsedHtml = BeautifulSoup(rawHtml, 'html.parser')
 
     imageElement = parsedHtml.find(attrs={"id" : "image"})
@@ -213,7 +213,7 @@ def fetchSafebooruTags(url):
 
 def fetchSankakuComplexChanTags(url):
     # Read the HTML content and parse it via BeautifulSoup.
-    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.7.1'}).text
+    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.7.2'}).text
     parsedHtml = BeautifulSoup(rawHtml, 'html.parser')
 
     parsedTags = []
@@ -226,7 +226,7 @@ def fetchSankakuComplexChanTags(url):
 
 def fetchSankakuComplexIdolTags(url):
     # Read the HTML content and parse it via BeautifulSoup.
-    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.7.1'}).text
+    rawHtml = requests.get(url, headers={'user-agent': 'sd-webui-booru-tags-to-prompt/1.7.2'}).text
     parsedHtml = BeautifulSoup(rawHtml, 'html.parser')
 
     parsedTags = []


### PR DESCRIPTION
Fixed typo in README.md.
Updated method used to determine which routine to run the tag import from to better support the alternative URL format. Bumped version to 1.7.2.

Closes #15 